### PR TITLE
Amores: add a `module` keyword with two modifiers (attributes).

### DIFF
--- a/rfcs/rfc00013.md
+++ b/rfcs/rfc00013.md
@@ -1,0 +1,280 @@
+Author:  Curtis "Ovid" Poe <curtis.poe@gmail.com>
+Sponsor: Paul "LeoNerd" Evans
+ID:
+Status:  Proposal
+Title:   "Amores", the procedural sister to "Corinna"
+
+**Note**: Paul asked that I submit this RFC, but he didn't specifically say he
+would be the sponsor. I'm just hoping :)
+
+# Abstract
+
+Add a `module` keyword with basic, modern features to support common Perl use
+cases.
+
+Like Corinna:
+
+    class My::Class :version(42) {
+        ...
+    }
+
+We have Amores, the procedural version, using a similarly structured KIM
+syntax (keyword, identifier, modifier:
+https://ovid.github.io/articles/language-design-consistency.html):
+
+    use feature 'module';
+
+    module My::Module :version(42) {
+        # these subs are examples only. Their behavior isn't part of the
+        # proposal, though `:export` is.
+        sub my_sub :export          ($arg1, $args2) { ... }
+        sub trim   :export(strings) ($string)       { ... }
+        sub ltrim  :export(strings) ($string)       { ... }
+        sub rtrim  :export(strings) ($string)       { ... }
+        sub inc    :export(numbers) ($num)          { ... }
+        sub dec    :export(numbers) ($num)          { ... }
+        sub munge                   ($thing)        { ... }
+    }
+
+    use My::Module qw(ltrim my_sub);
+    use My::Module ':strings';
+    use My::Module 'munge';     # fatal, No :export modifier
+
+# Motivation
+
+To bring more consistency and better defaults to Perl, but in a safe, lexical
+scope that offers a strong hint to the Perl developer that this is not your
+grandfather's Perl.
+
+# Rationale
+
+Sometimes we have a bunch of _things_ we'd like as defaults in Perl, but it's
+not always clear that we can enable them. Even something as simple as writing
+`use v5.36.0` can break legacy code unless we use a block to limit its scope.
+
+The idea behind Amores is to provide a convenient block-like structure with a
+syntax that mirrors Corinna, for a modern, consistent "feel" to the language.
+it's also designed to simplify exporting.
+
+# Syntax
+
+We add only one keyword: `module. Two modifiers (attributes) are added,
+`:version` and `:export` (`:version` also exists in Corinna and could be
+generally applicable outside the language.
+
+## `module`
+
+This is only enabled with `use feature 'module';`.
+
+The structure of this is:
+
+    module MODULE_NAME OPTIONAL_VERSION POSTFIXBLOCK
+
+At the end of the block, it yields a `1` whether you `use` or `require` it,
+eliminating the need for the trailing `1` (see also:
+https://github.com/Perl/perl5/issues/17921)
+
+Example:
+
+    module My::Module {
+        ...
+    }
+
+    module My::Module :version(42) {
+        ...
+    }
+
+The latter example is equivalent to:
+
+    package My::Module {
+        our $VERSION = 42;
+        use strict;
+        use warnings;
+		use feature 'signatures';
+        no feature 'indirect';
+        no feature 'multidimensional';
+        no feature 'bareword_filehandles';
+        ...
+    }
+
+The feature list is deliberately kept small and sane to minimize danger. `use
+utf8` was removed from the above list after P5P feedback. [This discussion was
+referenced](https://www.nntp.perl.org/group/perl.perl5.porters/2021/08/msg261164.html).
+
+Obviously, changing the feature list for this proposal is fine.
+
+## `:version(...)`
+
+Optionally declared after the module name (and _only_ after the module name to
+make it extremely predictable). Any valid version number may be specified.
+
+## `:export`
+
+This attribute controls exporting of functions from a module. It does not use
+the `import` mechanism, though if an `import` sub is found, it will still be
+called in the normal manner. It just won't be needed for importing.
+
+    module My::Module :version(42) {
+        # these subs are examples only. Their behavior isn't part of the
+        # proposal, though `:export` is.
+        sub my_sub :export          ($arg1, $args2) { ... }
+        sub trim   :export(strings) ($string)       { ... }
+        sub ltrim  :export(strings) ($string)       { ... }
+        sub rtrim  :export(strings) ($string)       { ... }
+        sub inc    :export(numbers) ($num)          { ... }
+        sub dec    :export(numbers) ($num)          { ... }
+        sub munge                   ($thing)        { ... }
+    }
+
+This would mostly follow the syntax of the
+[Perl6::Export::Attrs](https://metacpan.org/pod/Perl6::Export::Attrs) module,
+but with the following differences:
+
+* `:export` is lower case
+* User-specified export groups do not use a colon (`:export(strings, munging)`)
+* Built-in export behavior requires a colon prefix (`:export(:MANDATORY)`)
+
+Naturally, any subroutines without an `:export` tag are not available for
+export.
+
+It might be interesting to add the equivalent of `namespace::clean` behavior
+to ensure exports are lexical. However, this can sometimes make debugging
+painful.
+
+# Backwards Compatibility
+
+Currently, Amores' syntax is almost entirely backwards-compatible because
+the code does not parse on older Perls that `use strict`. This is helped
+tremendously by requiring a postfix block syntax which encapsulates the
+changes, rather than the standard `package Foo; sub {...}` syntax.
+
+    $ perl -Mstrict -Mwarnings -E 'module Foo { sub {...} }'
+    Odd number of elements in anonymous hash at -e line 1.
+    Can't locate object method "module" via package "Foo" (perhaps you forgot to load "Foo"?) at -e line 1.
+
+Various incantations all cause the similar failures. If `strict` is not used, you
+will get runtime failures with strange error messages due to indirect object
+syntax:
+
+    $ perl -e 'module Foo { my $x }'
+    Can't locate object method "module" via package "Foo" (perhaps you forgot to load "Foo"?) at -e line 1.
+
+In an unlikely case, if your older code uses `strict` but you have an empty
+module, you will also get errors due to indirect object syntax because Perl
+will think the block delimiters, `{ ... }` are a hashref and not a block.
+
+In an edge case, if have `module Foo { ... }` and you _already_ have a class by
+that name defined (and loaded) elsewhere, then Perl will try an indirect
+object method call and that might succeed, leading to strange errors:
+
+    package Foo {
+        sub module { print "darn it\n" }
+    };
+
+    module Foo {}  # prints "darn it"
+
+Note that we also intend for the block to have strict and warnings, along with
+disabling indirect method calls. Because those pragmas are file scoped without
+a block, requiring a block limits the damage, so to speak.
+
+# Tooling
+
+As for tooling, we hope that
+[`B::Deparse`](https://metacpan.org/pod/B::Deparse),
+[`Devel::Cover`](https://metacpan.org/pod/Devel::Cover), and
+[`Devel::NYTProf`](https://metacpan.org/pod/Devel::NYTProf), won't be impacted
+too strongly. However, this has not yet been tested.
+
+[`PPI`](https://metacpan.org/pod/PPI) (and thus
+[`Perl::Critic`](https://metacpan.org/pod/Perl::Critic) and friends) will be
+impacted.
+
+# Feature Guard
+
+For newer Perl's, Amores is not intended to be available by default. Instead,
+it will start with a feature guard:
+
+    use feature 'module';
+
+    module Some::Utils {
+        ...
+    }
+
+Later, it will likely be automatically available with `use v8;`, though I'm
+speculating about the version number.
+
+# Security Implications
+
+Most of what we plan leverages Perl's current capabilities, but with a
+different grammar. We don't anticipate particular security issues. In fact,
+due to increased encapsulation, Amores might actually be a bit more secure
+(in terms of behavior it exposes).
+
+# Scope for future work
+
+Plenty of scope, because we have a lexically scoped block to constrain
+changes, but for now, I think something small is the way to go.
+
+## Inner Modules
+
+It would be nice to see public and private inner modules which are hidden from
+the outside world. These would be analogous to the utility of inner classes.
+
+    module Math {
+        sub foo {
+            # available to Math::Integer and Math::Float, but not exposed
+            # publicly because it has no :export
+        }
+
+        module Integer { # exposed as Math::Integer
+            ...
+        }
+        module Float { # exposed as Math::Float
+            ...
+        }
+        module Some::Thing :private { # not exposed
+            # I'm less sure about the utility vis-a-vis inner classes
+            # because procedural code doesn't really have native requirements
+            # for state.
+        }
+    }
+
+Eventually, `package` could be used for older namespace declarations, while
+modules would be their own type and not necessarily exposed via the namespace
+mechanism unless they were public (or perhaps not even then).
+
+## Script Support
+
+Something like [Raku's MAIN
+function](https://docs.raku.org/language/create-cli) would make it easier to
+write scripts directly, rather than choosing (and arguing over) myriad
+command-line handling functions.
+
+# Why not stick with `package`?
+
+Because I want us to have something clearly analogous to Corinna in terms of
+structure (KIM syntax) and clearly something new to show movement rather than
+"here's a new feature we just tossed in." That last bits important because I
+want a to avoid the issue of us just throwing random features at Perl
+independently without them being thought out as a whole.
+
+I've thought about Amores for a long time and to be honest, it scratches my
+personal itches and it's not entirely fair to assume that everyone itches in
+the same spot. However, I've tried to ensure that this proposal is the
+simplest MVP that can be both effective and forward-looking and handles some
+of the worst nits of Perl.
+
+The syntax and intent of `module` mirrors the intent of `class`, but clearly
+on a much smaller scale because the core of Perl procedural code is pretty
+solid, but fine-tuning for common defaults is useful. And by using postfix
+blocks, we minimize the risk of these features leaking into "legacy" code. And
+if this remains experimental for a while and we want to add new features
+(e.g., inner modules), we have a fresh, new playground to play with that
+doesn't break older code.
+
+I think Amores an Corinna together _greatly_ improve the overall utility of
+Perl. Corinna makes modern OOP possible (and native), while Amores removes a
+number of warts. The actual value of Amores as a single proposal is marginal,
+but when coupled with Corinna, Perl starts moving towards a more consistent,
+modern future that's easier to reason about (especially when using KIM to
+limit keywords).        


### PR DESCRIPTION
This is an RFC to add a `module` keyword and two related attributes to provide a procedural companion to Corinna.

[Pre-RFC discussion is here](https://www.nntp.perl.org/group/perl.perl5.porters/2022/01/msg262535.html).