### PR TITLE
New RFC: "yield_true" at end of compilation

### DIFF
--- a/rfcs/rfc0018.md
+++ b/rfcs/rfc0018.md
@@ -1,0 +1,69 @@
+# A feature to automatically "yield true" at the end of a file
+
+## Preamble
+
+    Author:  Curtis "Ovid" Poe <curtis.poe@gmail.com>
+    Sponsor:
+    ID:      0018
+    Status:  Draft
+
+## Abstract
+
+This RFC proposes a `yield_true` feature. When used, the current Perl _file_
+containing `use feature 'yield_true'l` will automatically return a true value
+after successful compilation, eliminating the neeed for a "1" (or other true
+value) at the end of the file.
+
+## Motivation
+
+Eliminate the need for a true value at the end of a Perl file.
+
+## Rationale
+
+There's no need to have a true value be hard-coded in our files that we
+`use`. Further, newer programmers can get confused because sometimes code
+_doesn't_ end with a true value but nonetheless compiles just fine because
+_something_ in the code returned a true value and the code compiles as a
+side-effect.
+
+
+## Specification
+
+    use feature 'yield_true';
+
+Code using the above does not need to return a magic true value when compiled.
+
+## Backwards Compatibility
+
+There are no compatibility concerns I'm aware of.
+
+## Security Implications
+
+None expected.
+
+## Examples
+
+None. See above.
+
+## Prototype Implementation
+
+None.
+
+## Future Scope
+
+I believe this is complete.
+
+## Rejected Ideas
+
+None that I'm aware of.
+
+## Open Issues
+
+None that I'm aware of.
+
+## Copyright
+
+Copyright (C) 2022, Curtis "Ovid" Poe
+
+This document and code and documentation within it may be used, redistributed
+and/or modified under the same terms as Perl itself.


### PR DESCRIPTION
This RFC is to eliminate the need for a magic true value (usually a hard-coded trailing `1`) being required in code we use.

I guess as to the RFC number. If there is a process for assigning them, I've missed it. My apologies.

Better names than `yield_true` are welcome. I was tempted to go with `use feature 'neo';` because "Neo is the One", but it's  terrible name, even though it amuses me :)