### PR TITLE
RFC 0006 - Rename `load` to `load_module`

### DIFF
--- a/rfcs/rfc0006.md
+++ b/rfcs/rfc0006.md
@@ -1,4 +1,4 @@
-# Module Loading with "load"
+# Module Loading with "load\_module"
 
 ## Preamble
 
@@ -9,8 +9,8 @@
 
 ## Abstract
 
-This RFC proposes a new built-in, "load", to load modules by module name
-(rather than filename) at runtime.
+This RFC proposes a new built-in, "load\_module", to load modules by module
+name (rather than filename) at runtime.
 
 ## Motivation
 
@@ -32,20 +32,20 @@ eliminates argument about what or how.
 ## Specification
 
 ```pod
-=item load EXPR
+=item load_module EXPR
 
 This loads a named module from the inclusion paths (C<@INC>).  EXPR must be
 a string that provides a module name.  It cannot be omitted, and providing
 an invalid module name will result in an exception.
 
-The effect of C<load>-ing a module is the same as C<require>-ing, down to
-the same error conditions when the module does not exist, does not compile,
+The effect of C<load_module>-ing a module is the same as C<require>-ing, down
+to the same error conditions when the module does not exist, does not compile,
 or does not evalute to a true value.
 
-C<load> can't be used to require a particular version of Perl, nor can it
-be given a bareword module name as an argument.
+C<load_module> can't be used to require a particular version of Perl, nor can
+it be given a bareword module name as an argument.
 
-C<load> is only available when requested.
+C<load_module> is only available when requested.
 ```
 
 Note:  The "how" of "when requested" is to be determined.  If implemented
@@ -75,7 +75,7 @@ A simple use case might be:
 my $config = read_config;
 for my $module (keys $config->{prereq}->%*) {
   my ($version) = $config->{prereq}{$module};
-  load $module;
+  load_module $module;
   $module->VERSION($version) if defined $version;
 }
 ```
@@ -94,7 +94,7 @@ errors.
 
 These problems already exist with `use` and `require`.  Addressing them through
 more clearly-defined exceptions has been proposed in the past, and this RFC has
-not attempted to fix them just for `load`.  Instead, a future fix should
+not attempted to fix them just for `load_module`.  Instead, a future fix should
 address all at once.
 
 ## Rejected Ideas


### PR DESCRIPTION
Objections were raised at the rather short and inspecific `load`; suggested that we rename this to `load_module`.